### PR TITLE
Fix for issue #11

### DIFF
--- a/cm_text/message.py
+++ b/cm_text/message.py
@@ -15,7 +15,8 @@ class Message:
     def __init__(self, body='', **kwargs):
         self.body = body
         self.type = kwargs.get('type', MessageBodyTypes.AUTO)
-        self.from_ = kwargs.get('from', self.sender_fallback)
+        # 'from' is a Python keyword, used in imports, therefore using 'from_'
+        self.from_ = kwargs.get('from_', self.sender_fallback)
         self.to = kwargs.get('to', [])
         self.reference = kwargs.get('reference')
         self.allowedChannels = kwargs.get('allowedChannels')


### PR DESCRIPTION
The Message() class looked for 'from' as a constructor parameter, but because 'from' is a Python keyword, we use 'from_'. All instantiations of the Message class already use 'from_' to pass the sender, so this needs to be changed in the constructor. Fixes issue #11